### PR TITLE
Add SIGHUP-triggered reconciliation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -300,6 +300,16 @@ func main() {
 		}
 	}
 
+	if err = mgr.Add(&sighupTrigger{
+		client:    client,
+		logger:    logger,
+		hostname:  hostname,
+		namespace: cfg.ControllerConfig.Namespace,
+	}); err != nil {
+		setupLog.Error(err, "unable to add SIGHUP trigger")
+		os.Exit(1)
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err = mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/cmd/sighup.go
+++ b/cmd/sighup.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	commonv1 "github.com/zachfi/nodemanager/api/common/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// nodePatcher is the subset of client.Client used by sighupTrigger.
+type nodePatcher interface {
+	Get(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error
+	Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error
+}
+
+// sighupTrigger is a manager.Runnable that listens for SIGHUP and triggers
+// reconciliation of the local ManagedNode by patching a timestamp annotation.
+// The existing configSetsOnNodeChange watch maps the ManagedNode change to all
+// matching ConfigSets, so both the ManagedNode and ConfigSet reconcilers are
+// re-queued without any changes to the controllers themselves.
+type sighupTrigger struct {
+	client    nodePatcher
+	logger    *slog.Logger
+	hostname  string
+	namespace string
+}
+
+func (s *sighupTrigger) Start(ctx context.Context) error {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGHUP)
+	defer signal.Stop(ch)
+
+	for {
+		select {
+		case <-ch:
+			s.logger.Info("SIGHUP received, triggering reconciliation")
+			if err := s.trigger(ctx); err != nil {
+				s.logger.Error("failed to trigger reconciliation via SIGHUP", "err", err)
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (s *sighupTrigger) trigger(ctx context.Context) error {
+	var node commonv1.ManagedNode
+	if err := s.client.Get(ctx, types.NamespacedName{Name: s.hostname, Namespace: s.namespace}, &node); err != nil {
+		return err
+	}
+	patch := client.MergeFrom(node.DeepCopy())
+	if node.Annotations == nil {
+		node.Annotations = make(map[string]string)
+	}
+	node.Annotations["nodemanager.io/reconcile-trigger"] = time.Now().UTC().Format(time.RFC3339)
+	return s.client.Patch(ctx, &node, patch)
+}

--- a/cmd/sighup.go
+++ b/cmd/sighup.go
@@ -13,6 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const reconcileTriggerAnnotation = "nodemanager.io/reconcile-trigger"
+
 // nodePatcher is the subset of client.Client used by sighupTrigger.
 type nodePatcher interface {
 	Get(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error
@@ -29,12 +31,19 @@ type sighupTrigger struct {
 	logger    *slog.Logger
 	hostname  string
 	namespace string
+	// ready is closed after signal.Notify returns, giving tests a deterministic
+	// synchronisation point before sending SIGHUP. Leave nil in production.
+	ready chan struct{}
 }
 
 func (s *sighupTrigger) Start(ctx context.Context) error {
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGHUP)
 	defer signal.Stop(ch)
+
+	if s.ready != nil {
+		close(s.ready)
+	}
 
 	for {
 		select {
@@ -58,6 +67,6 @@ func (s *sighupTrigger) trigger(ctx context.Context) error {
 	if node.Annotations == nil {
 		node.Annotations = make(map[string]string)
 	}
-	node.Annotations["nodemanager.io/reconcile-trigger"] = time.Now().UTC().Format(time.RFC3339)
+	node.Annotations[reconcileTriggerAnnotation] = time.Now().UTC().Format(time.RFC3339)
 	return s.client.Patch(ctx, &node, patch)
 }

--- a/cmd/sighup_test.go
+++ b/cmd/sighup_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonv1 "github.com/zachfi/nodemanager/api/common/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// fakeNodePatcher implements nodePatcher for tests.
+type fakeNodePatcher struct {
+	mu   sync.Mutex
+	node commonv1.ManagedNode
+}
+
+func (f *fakeNodePatcher) Get(_ context.Context, _ types.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	*obj.(*commonv1.ManagedNode) = *f.node.DeepCopy()
+	return nil
+}
+
+func (f *fakeNodePatcher) Patch(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.node = *obj.(*commonv1.ManagedNode).DeepCopy()
+	return nil
+}
+
+func (f *fakeNodePatcher) annotations() map[string]string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.node.Annotations
+}
+
+func newFakePatcher() *fakeNodePatcher {
+	return &fakeNodePatcher{
+		node: commonv1.ManagedNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-node", Namespace: "default"},
+		},
+	}
+}
+
+func TestSighupTrigger_Trigger(t *testing.T) {
+	fp := newFakePatcher()
+	trig := &sighupTrigger{
+		client:    fp,
+		logger:    slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		hostname:  "test-node",
+		namespace: "default",
+	}
+
+	require.NoError(t, trig.trigger(context.Background()))
+
+	ann := fp.annotations()
+	require.Contains(t, ann, "nodemanager.io/reconcile-trigger")
+
+	ts, err := time.Parse(time.RFC3339, ann["nodemanager.io/reconcile-trigger"])
+	require.NoError(t, err)
+	require.WithinDuration(t, time.Now().UTC(), ts, 5*time.Second)
+}
+
+func TestSighupTrigger_Trigger_PreservesExistingAnnotations(t *testing.T) {
+	fp := newFakePatcher()
+	fp.node.Annotations = map[string]string{"existing-key": "existing-value"}
+
+	trig := &sighupTrigger{
+		client:    fp,
+		logger:    slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		hostname:  "test-node",
+		namespace: "default",
+	}
+
+	require.NoError(t, trig.trigger(context.Background()))
+
+	ann := fp.annotations()
+	require.Equal(t, "existing-value", ann["existing-key"], "existing annotations must be preserved")
+	require.Contains(t, ann, "nodemanager.io/reconcile-trigger")
+}
+
+func TestSighupTrigger_Start_RespondsToSIGHUP(t *testing.T) {
+	fp := newFakePatcher()
+	trig := &sighupTrigger{
+		client:    fp,
+		logger:    slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		hostname:  "test-node",
+		namespace: "default",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = trig.Start(ctx)
+	}()
+
+	// Give the goroutine time to register the signal handler.
+	time.Sleep(20 * time.Millisecond)
+
+	p, err := os.FindProcess(os.Getpid())
+	require.NoError(t, err)
+	require.NoError(t, p.Signal(syscall.SIGHUP))
+
+	require.Eventually(t, func() bool {
+		_, ok := fp.annotations()["nodemanager.io/reconcile-trigger"]
+		return ok
+	}, 2*time.Second, 20*time.Millisecond, "annotation must appear after SIGHUP")
+
+	cancel()
+	<-done
+}

--- a/cmd/sighup_test.go
+++ b/cmd/sighup_test.go
@@ -62,9 +62,9 @@ func TestSighupTrigger_Trigger(t *testing.T) {
 	require.NoError(t, trig.trigger(context.Background()))
 
 	ann := fp.annotations()
-	require.Contains(t, ann, "nodemanager.io/reconcile-trigger")
+	require.Contains(t, ann, reconcileTriggerAnnotation)
 
-	ts, err := time.Parse(time.RFC3339, ann["nodemanager.io/reconcile-trigger"])
+	ts, err := time.Parse(time.RFC3339, ann[reconcileTriggerAnnotation])
 	require.NoError(t, err)
 	require.WithinDuration(t, time.Now().UTC(), ts, 5*time.Second)
 }
@@ -84,16 +84,18 @@ func TestSighupTrigger_Trigger_PreservesExistingAnnotations(t *testing.T) {
 
 	ann := fp.annotations()
 	require.Equal(t, "existing-value", ann["existing-key"], "existing annotations must be preserved")
-	require.Contains(t, ann, "nodemanager.io/reconcile-trigger")
+	require.Contains(t, ann, reconcileTriggerAnnotation)
 }
 
 func TestSighupTrigger_Start_RespondsToSIGHUP(t *testing.T) {
 	fp := newFakePatcher()
+	ready := make(chan struct{})
 	trig := &sighupTrigger{
 		client:    fp,
 		logger:    slog.New(slog.NewTextHandler(os.Stdout, nil)),
 		hostname:  "test-node",
 		namespace: "default",
+		ready:     ready,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -105,15 +107,14 @@ func TestSighupTrigger_Start_RespondsToSIGHUP(t *testing.T) {
 		_ = trig.Start(ctx)
 	}()
 
-	// Give the goroutine time to register the signal handler.
-	time.Sleep(20 * time.Millisecond)
+	<-ready // wait until signal.Notify has been called
 
 	p, err := os.FindProcess(os.Getpid())
 	require.NoError(t, err)
 	require.NoError(t, p.Signal(syscall.SIGHUP))
 
 	require.Eventually(t, func() bool {
-		_, ok := fp.annotations()["nodemanager.io/reconcile-trigger"]
+		_, ok := fp.annotations()[reconcileTriggerAnnotation]
 		return ok
 	}, 2*time.Second, 20*time.Millisecond, "annotation must appear after SIGHUP")
 


### PR DESCRIPTION
## Summary

- Adds a `sighupTrigger` manager.Runnable that listens for `SIGHUP` and patches a `nodemanager.io/reconcile-trigger` timestamp annotation on the local ManagedNode
- The existing `configSetsOnNodeChange` watch maps any ManagedNode change to all matching ConfigSets, so both reconcilers are re-queued with no changes to either controller
- Starts after the cache is synced (via `mgr.Add`), so the client is always ready; signal errors are logged and do not crash the process
- Uses a narrow `nodePatcher` interface to keep the implementation testable without vendoring `controller-runtime/pkg/client/fake`

## Test plan

- [ ] `TestSighupTrigger_Trigger` — verifies annotation is set with a valid RFC3339 timestamp
- [ ] `TestSighupTrigger_Trigger_PreservesExistingAnnotations` — verifies existing annotations are not clobbered
- [ ] `TestSighupTrigger_Start_RespondsToSIGHUP` — sends a live SIGHUP to the process and asserts the annotation appears within 2s

Run with `make test` or `go test ./cmd/... -run TestSighup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)